### PR TITLE
Add automated testing in python 2 & 3 with tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
 # command to install dependencies
 install:
     - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,38 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
+python: '3.5'
 # command to install dependencies
+
+env:
+  global:
+    - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
+    - SEGFAULT_SIGNALS=all
+  matrix:
+    - TOXENV=py26
+    - TOXENV=py27
+    - TOXENV=py33
+    - TOXENV=py34
+    - TOXENV=py35
+before_install:
+  - python --version
+  - uname -a
+  - lsb_release -a
 install:
-    - python setup.py install
+  - pip install tox
+  - virtualenv --version
+  - easy_install --version
+  - pip --version
+  - tox --version
 # command to run tests
-script: nosetests
+script:
+  - tox -v
+after_failure:
+  - more .tox/log/* | cat
+  - more .tox/*/log/* | cat
+before_cache:
+  - rm -rf $HOME/.cache/pip/log
+cache:
+  directories:
+    - $HOME/.cache/pip
 branches:
   only:
     - master

--- a/axolotl/__init__.py
+++ b/axolotl/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.7"
+__version__ = "0.1.7-p1"
 __author__ = "Tarek Galal"

--- a/axolotl/sessioncipher.py
+++ b/axolotl/sessioncipher.py
@@ -62,9 +62,11 @@ class SessionCipher:
 
         return ciphertextMessage
 
-    def decryptMsg(self, ciphertext):
+    def decryptMsg(self, ciphertext, textMsg=True):
         """
         :type ciphertext: WhisperMessage
+        :type textMsg: Bool set this to False if you are decrypting bytes
+                       instead of string
         """
 
         if not self.sessionStore.containsSession(self.recipientId, self.deviceId):
@@ -75,11 +77,11 @@ class SessionCipher:
 
         self.sessionStore.storeSession(self.recipientId, self.deviceId, sessionRecord)
 
-        if sys.version_info >= (3,0):
+        if sys.version_info >= (3,0) and textMsg:
             return plaintext.decode()
         return plaintext
 
-    def decryptPkmsg(self, ciphertext):
+    def decryptPkmsg(self, ciphertext, textMsg=True):
         """
         :type ciphertext: PreKeyWhisperMessage
         """
@@ -93,7 +95,7 @@ class SessionCipher:
         if unsignedPreKeyId is not None:
             self.preKeyStore.removePreKey(unsignedPreKeyId)
 
-        if sys.version_info >= (3, 0):
+        if sys.version_info >= (3, 0) and textMsg:
             return plaintext.decode()
         return plaintext
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
 from __future__ import print_function
-from setuptools import setup, find_packages
-import axolotl
 
-deps = ["protobuf>=2.6,<3.0.0-alpha-2", "pycrypto", "python-axolotl-curve25519"]
+import sys
+
+import axolotl
+from setuptools import find_packages, setup
+
+deps = ["pycrypto", "python-axolotl-curve25519"]
+
+if sys.version_info < (3, 0):
+    deps += ["protobuf>=2.6,<3.0.0-alpha-2"]
+else:
+    deps += ["protobuf==3.0.0.b2"]
 
 setup(
     name='python-axolotl',

--- a/setup.py
+++ b/setup.py
@@ -5,21 +5,20 @@ import sys
 import axolotl
 from setuptools import find_packages, setup
 
-deps = ["pycrypto", "python-axolotl-curve25519"]
+deps = ['pycrypto', 'python-axolotl-curve25519']
 
 if sys.version_info < (3, 0):
-    deps += ["protobuf>=2.6,<3.0.0-alpha-2"]
+    deps += ['protobuf>=2.6,<3.0.0-alpha-2']
 else:
-    deps += ["protobuf==3.0.0.b2"]
+    deps += ['protobuf==3.0.0.b2']
 
 setup(
     name='python-axolotl',
-    version=axolotl.__version__ ,
-    packages= find_packages(),
-    install_requires = deps,
+    version=axolotl.__version__,
+    packages=find_packages(),
+    install_requires=deps,
     license='GPLv3 License',
     author='Tarek Galal',
     author_email='tare2.galal@gmail.com',
-    description="Python port of libaxolotl-android, originally written by Moxie Marlinspik",
-    platforms='any'
-)
+    description='Python port of libaxolotl-android, originally written by Moxie Marlinspik',
+    platforms='any')

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,9 @@ envlist = py26, py27, py32, py33, py34
 commands = nosetests axolotl.tests
 deps =
     nose
-    protobuf>=2.6,<3.0.0-alpha-2
+    py26: protobuf>=2.6,<3.0.0
+    py27: protobuf>=2.6,<3.0.0
+    py33: protobuf==3.0.0b2
+    py34: protobuf==3.0.0b2
     pycrypto
     python-axolotl-curve25519

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+skip_missing_interpreters = true
+envlist = py26, py27, py32, py33, py34
+
+[testenv]
+commands = nosetests axolotl.tests
+deps =
+    nose
+    protobuf>=2.6,<3.0.0-alpha-2
+    pycrypto
+    python-axolotl-curve25519

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 skip_missing_interpreters = true
-envlist = py26, py27, py32, py33, py34
+envlist = py26, py27, py32, py33, py34, py35
 
 [testenv]
 commands = nosetests axolotl.tests
@@ -15,5 +15,6 @@ deps =
     py27: protobuf>=2.6,<3.0.0
     py33: protobuf==3.0.0b2
     py34: protobuf==3.0.0b2
+    py35: protobuf==3.0.0b2
     pycrypto
     python-axolotl-curve25519


### PR DESCRIPTION
This pull request provides a tox config and a modified Travis CI config. Using
`tox` simplifies testing in multiple python versions. Just execute `tox` and if
it passes everything is fine. Not installed python versions will be skipped and
checked by Travis CI.