### PR TITLE
fix for inconsistent role comparison with java impl (see issue #12)

### DIFF
--- a/axolotl/ecc/djbec.py
+++ b/axolotl/ecc/djbec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import binascii
+import struct
 
 from .ec import ECPublicKey, ECPrivateKey
 from ..util.byteutil import ByteUtil
@@ -29,14 +29,14 @@ class DjbECPublicKey(ECPublicKey):
         return self.publicKey == other.getPublicKey()
 
     def __lt__(self, other):
-        myVal = int(binascii.hexlify(self.publicKey), 16)
-        otherVal = int(binascii.hexlify(other.getPublicKey()), 16)
+        myVal = struct.unpack(">8i", self.publicKey)
+        otherVal = struct.unpack(">8i", other.getPublicKey())
 
         return myVal < otherVal
 
     def __cmp__(self, other):
-        myVal = int(binascii.hexlify(self.publicKey), 16)
-        otherVal = int(binascii.hexlify(other.getPublicKey()), 16)
+        myVal = struct.unpack(">8i", self.publicKey)
+        otherVal = struct.unpack(">8i", other.getPublicKey())
 
         if myVal < otherVal:
             return -1


### PR DESCRIPTION
background: in RatchetingSession.isAlice the java code does a comparison of 2 certificates by making a java.math.BigInteger object with the byte arrays of each cert.

the java mechanism using big-endian and returns a signed integer (https://docs.oracle.com/javase/7/docs/api/java/math/BigInteger.html#BigInteger(byte[])

the current python mechanism returns an unsigned integer:
int(binascii.hexlify(self.publicKey), 16)

this leads to the non-derterministic results between java and python.  this change from my testing leads to a deterministic result by reading the bytes into a tuple of signed ints and then uses tuple comparison