### PR TITLE
Use cryptography instead of pycrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Read rest of of details [here](https://github.com/WhisperSystems/libaxolotl-andr
 The library has some dependencies which are automatically pulled and installed if you use the instructions below for your OS
 
  - [protobuf 2.6+](https://github.com/google/protobuf/)
- - [pycrypto](https://www.dlitz.net/software/pycrypto/)
+ - [cryptography](https://cryptography.io)
  - [python-axolotl-curve25519](https://github.com/tgalal/python-axolotl-curve25519)
 
 ## Linux
@@ -45,10 +45,6 @@ compiler=mingw32
  - Install gcc: ```mingw-get.exe install gcc```
  - Install [zlib](http://www.zlib.net/)
  - ```python setup.py install```
-
-If pycrypto fails to install with some "chmod error". You can install it separately using something like 
-```easy_install http://www.voidspace.org.uk/downloads/pycrypto26/pycrypto-2.6.win32-py2.7.exe```
-and then rerun the install command again
 
 
 # Usage

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 import axolotl
 from setuptools import find_packages, setup
 
-deps = ['pycrypto', 'python-axolotl-curve25519', 'protobuf>=3.0.0.b2']
+deps = ['cryptography', 'python-axolotl-curve25519', 'protobuf>=3.0.0.b2']
 
 setup(
     name='python-axolotl',

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,5 @@ commands = nosetests axolotl.tests
 deps =
     nose
     protobuf==3.0.0b2
-    pycrypto
+    cryptography
     python-axolotl-curve25519


### PR DESCRIPTION
pycrypto is not maintained anymore and users dont want to install it

This patch uses cryptography instead

right now the V2 tests fail because of a decoding error, i dont understand why, maybe someone can help.