### PR TITLE
Removes IV paramenter from AES constructor, since it is not necessary for ctr mode.

### DIFF
--- a/axolotl/sessioncipher.py
+++ b/axolotl/sessioncipher.py
@@ -228,13 +228,7 @@ class SessionCipher:
         # counterint = struct.unpack(">L", counterbytes)[0]
         # counterint = int.from_bytes(counterbytes, byteorder='big')
         ctr = Counter.new(128, initial_value=counter)
-
-        # cipher = AES.new(key, AES.MODE_CTR, counter=ctr)
-        ivBytes = bytearray(16)
-        ByteUtil.intToByteArray(ivBytes, 0, counter)
-
-        cipher = AES.new(key, AES.MODE_CTR, IV=bytes(ivBytes), counter=ctr)
-
+        cipher = AES.new(key, AES.MODE_CTR, counter=ctr)
         return cipher
 
 


### PR DESCRIPTION
This patch is taken from the Debian package of python-axolotl.

Recent versions of pycrypto die if you give AES both an IV and counter in CTR mode.

https://github.com/dlitz/pycrypto/blob/master/src/block_template.c#L169